### PR TITLE
Add Swagger document filter based on wallet type

### DIFF
--- a/src/HDWallet.Api/Startup.cs
+++ b/src/HDWallet.Api/Startup.cs
@@ -54,6 +54,9 @@ namespace HDWallet.Api
             services.AddSwaggerGen(
                 options =>
                 {
+                    // add a custom document filter which sets visible routes
+                    options.DocumentFilter<SwaggerDocumentFilter>();
+
                     // add a custom operation filter which sets default values
                     options.OperationFilter<SwaggerDefaultValues>();
 

--- a/src/HDWallet.Api/SwaggerDocumentFilter.cs
+++ b/src/HDWallet.Api/SwaggerDocumentFilter.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace HDWallet.Api
+{
+    /// <summary>
+    /// Represents the Swagger/Swashbuckle document filter used to set the visible API routes.
+    /// </summary>
+    public class SwaggerDocumentFilter : IDocumentFilter
+    {
+        private readonly Settings _settings;
+
+        public SwaggerDocumentFilter(Settings settings)
+        {
+            _settings = settings;
+        }
+
+        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+        {
+            var shouldHdWalletVisible = !string.IsNullOrWhiteSpace(_settings.Mnemonic);
+            var willBeHiddenRoutes = swaggerDoc.Paths
+                .Where(x => !x.Key.ToLower().Contains("account") == shouldHdWalletVisible)
+                .ToList();
+            willBeHiddenRoutes.ForEach(x => { swaggerDoc.Paths.Remove(x.Key); });
+        }
+    }
+}


### PR DESCRIPTION
Added Swagger document filter
- HD wallet routes won't be listed on Swagger UI when environment variables set for regular wallet
- Regular wallet routes won't be listed on Swagger UI when environment variables set for HD wallet 