### PR TITLE
Add selected coins argument and optional Swagger document filter

### DIFF
--- a/src/HDWallet.Api/Program.cs
+++ b/src/HDWallet.Api/Program.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace HDWallet.Api
 {

--- a/src/HDWallet.Api/Settings.cs
+++ b/src/HDWallet.Api/Settings.cs
@@ -11,7 +11,9 @@ namespace HDWallet.Api
         public string AccountHDKey { get; set; }
         
         public uint AccountNumber { get; set; }
-        
+
+        public string[] SelectedCoinEndpoints { get; set; }
+
         public void Validate() 
         {
             if(string.IsNullOrWhiteSpace(this.Mnemonic) && string.IsNullOrWhiteSpace(this.AccountHDKey))

--- a/src/HDWallet.Core/CoinArguments.cs
+++ b/src/HDWallet.Core/CoinArguments.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+
+namespace HDWallet.Core
+{
+    public static class CoinArguments
+    {
+        public static readonly List<CoinArgumentModel> EndpointList =
+            new List<CoinArgumentModel>
+            {
+                new CoinArgumentModel
+                {
+                    Argument = "avax",
+                    EndpointFilter = "Avalanche"
+                },
+                new CoinArgumentModel
+                {
+                    Argument = "fil",
+                    EndpointFilter = "Filecoin"
+                },
+                new CoinArgumentModel
+                {
+                    Argument = "trx",
+                    EndpointFilter = "Tron"
+                }
+            };
+    }
+
+    public class CoinArgumentModel
+    {
+        public string Argument { get; set; }
+        public string EndpointFilter { get; set; }
+    }
+}

--- a/src/HDWallet.Core/Helper.cs
+++ b/src/HDWallet.Core/Helper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -42,6 +43,20 @@ namespace HDWallet.Core
             }
             return bytes;
         }
-        
+
+        public static string[] GetEndpointFromCoinArgument(string[] coinArgs)
+        {
+	        var endpointFilter = new List<string>();
+	        foreach (var arg in coinArgs)
+	        {
+		        var filter = CoinArguments.EndpointList.FirstOrDefault(coin => coin.Argument == arg);
+		        if (filter == null)
+		        {
+			        continue;
+		        }
+		        endpointFilter.Add(filter.EndpointFilter);
+	        }
+	        return endpointFilter.ToArray();
+        }
     }
 }


### PR DESCRIPTION
Pass selected coin argument when running project #19 
- Added optional **coins** argument in order to detect it in Swagger requests
- Added **coins** option into the existing customized Swagger document filter
- Supported coins: **avax**, **fil**, **trx**

Usage --> `dotnet run --coins=avax,trx`